### PR TITLE
First Dominator Implementation Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,8 @@ Daedalus is an out-of-tree LLVM pass. Therefore, you can compile and install it 
 
 ```shell
 $ mkdir build
-$ cd build
-$ cmake -DLLVM_DIR={path_to_llvm_project} ../
-$ cmake --build .
+$ cmake -DLLVM_DIR=$(llvm-config --cmakedir) -S . -B build
+$ cmake --build build
 ```
 
 **Disclaimer**: This pass depends on a custom fork of [LLVM 17](https://github.com/Casperento/llvm-project/tree/merge-functions-pass).

--- a/include/ProgramSlice.h
+++ b/include/ProgramSlice.h
@@ -128,7 +128,7 @@ private:
                                    BasicBlock *unreachableBlock,
                                    const PostDominatorTree &PDT);
 
-  Value *getClonedOrUndef(Value *origCond, BasicBlock *context);
+  Value *getClonedCond(Value *origCond);
 
   /// Determines the target block for a successor, potentially finding a
   /// dominated node if direct mapping fails.

--- a/lib/PHIGateAnalyzer.cpp
+++ b/lib/PHIGateAnalyzer.cpp
@@ -183,7 +183,7 @@ void PHIGateAnalyzer::collectGates(
           collectGates(arg.Lhs, Gates, Visited);
           collectGates(arg.Rhs, Gates, Visited);
         } else if constexpr (std::is_same_v<T, SpecialExpr>) {
-          // ~secial case~ The paper assumes that SpecialExpr is an
+          // ~special case~ The paper assumes that SpecialExpr is an
           // unconditional branch, then a lambda expression is set with the
           // controlling predecessor. But we want to propagate the gate of that
           // predecessor, so we collect the predecessor's gates.

--- a/lib/ProgramSlice.cpp
+++ b/lib/ProgramSlice.cpp
@@ -838,14 +838,21 @@ BasicBlock *ProgramSlice::getNewTargetByFirstDominator(
     if (!visited.insert(curBB).second) continue;
     if (curBB == originalBB) continue; // skip the source block itself
 
+    // Second try:
+    // If the current block is not post-dominated by the initial block, skip it
+    // if (!PDT.dominates(_initial->getParent(), curBB)) {
+    //   return nullptr;
+    // }
+
+    // Second try:
     // Skip traversing from loop latches or blocks outside the current loop
-    if (_loop) {
-      if (_loop->contains(curBB)) {
-        if (_loop->isLoopLatch(curBB)) continue;
-      } else {
-        continue;
-      }
-    }
+    // if (_loop) {
+    //   if (_loop->contains(curBB)) {
+    //     if (_loop->isLoopLatch(curBB)) continue;
+    //   } else {
+    //     continue;
+    //   }
+    // }
 
     LLVM_DEBUG(dbgs() << "\t\tVisiting CFG block: " << curBB->getName()
                       << "\n");

--- a/lib/ProgramSlice.cpp
+++ b/lib/ProgramSlice.cpp
@@ -137,7 +137,7 @@ std::pair<Status, dataDependence> getDataDependencies(
 
   // Helper to process operands
   auto processOperand = [&](const Value *operand) {
-    if (isa<GlobalVariable>(operand)) { // ~special case~
+    if (isa<GlobalVariable>(operand)) {
       status = {false, "Some dependency is on a Global Variable."};
       return false;
     }
@@ -672,13 +672,13 @@ void ProgramSlice::reconstructTerminator(BasicBlock &BB,
       BranchInst::Create(targets[0], &BB);
       updatePHINodesForSuccessor(targets[0], origBB, &BB);
     } else {
-      Value *cond = getClonedOrUndef(origBranch->getCondition(), &BB);
+      Value *cond = getClonedCond(origBranch->getCondition());
       BranchInst::Create(targets[0], targets[1], cond, &BB);
       updatePHINodesForSuccessor(targets[0], origBB, &BB);
       updatePHINodesForSuccessor(targets[1], origBB, &BB);
     }
   } else if (auto *origSwitch = dyn_cast<SwitchInst>(origTerm)) {
-    Value *cond = getClonedOrUndef(origSwitch->getCondition(), &BB);
+    Value *cond = getClonedCond(origSwitch->getCondition());
     SwitchInst *newSwitch = SwitchInst::Create(cond, unreachableBlock,
                                                origSwitch->getNumCases(), &BB);
     for (auto &Case : origSwitch->cases()) {
@@ -690,7 +690,6 @@ void ProgramSlice::reconstructTerminator(BasicBlock &BB,
     BasicBlock *def =
         getOrCreateTargetBlock(origSwitch->getDefaultDest(), origBB, DT, PDT);
     newSwitch->setDefaultDest(def ? def : unreachableBlock);
-    // Optionally, update PHI nodes here too
   }
 }
 
@@ -721,14 +720,16 @@ void ProgramSlice::rerouteTerminatorSuccessors(
       updatePHINodesForSuccessor(target, origBB, &BB);
     }
   }
-  // Optionally handle other multi-successor terminators
 }
 
-Value *ProgramSlice::getClonedOrUndef(Value *origCond, BasicBlock *context) {
-  if (!origCond) return UndefValue::get(Type::getInt1Ty(context->getContext()));
+Value *ProgramSlice::getClonedCond(Value *origCond) {
   if (auto *inst = dyn_cast<Instruction>(origCond)) {
     auto it = _origToNewInst.find(inst);
     if (it != _origToNewInst.end()) return it->second;
+  }
+  if (auto *arg = dyn_cast<Argument>(origCond)) {
+    auto it = std::find(_depArgs.begin(), _depArgs.end(), arg);
+    if (it != _depArgs.end()) return *it;
   }
   return UndefValue::get(origCond->getType());
 }
@@ -753,13 +754,8 @@ BasicBlock *ProgramSlice::getOrCreateTargetBlock(const BasicBlock *successor,
                                                  const BasicBlock *originalBB,
                                                  const DominatorTree &DT,
                                                  const PostDominatorTree &PDT) {
-  if (_loop && !_loop->contains(successor)) {
-    return nullptr;
-  }
-
   BasicBlock *newTarget =
       getNewTargetByFirstDominator(successor, originalBB, DT, PDT);
-
   return newTarget;
 }
 
@@ -838,21 +834,20 @@ BasicBlock *ProgramSlice::getNewTargetByFirstDominator(
     if (!visited.insert(curBB).second) continue;
     if (curBB == originalBB) continue; // skip the source block itself
 
-    // Second try:
-    // If the current block is not post-dominated by the initial block, skip it
-    // if (!PDT.dominates(_initial->getParent(), curBB)) {
-    //   return nullptr;
-    // }
-
-    // Second try:
-    // Skip traversing from loop latches or blocks outside the current loop
-    // if (_loop) {
-    //   if (_loop->contains(curBB)) {
-    //     if (_loop->isLoopLatch(curBB)) continue;
-    //   } else {
-    //     continue;
-    //   }
-    // }
+    // Skip traversing from loop header or blocks outside the current loop
+    if (_loop && !_loop->isInvalid()) {
+      if (_loop->contains(curBB)) {
+        if (_loop->getHeader() == curBB) {
+          LLVM_DEBUG(dbgs() << "\t\tCFG block is a loop header: "
+                            << curBB->getName() << "\n");
+          continue;
+        }
+      } else {
+        LLVM_DEBUG(dbgs() << "\t\tCFG block is not in loop: "
+                          << curBB->getName() << "\n");
+        continue;
+      }
+    }
 
     LLVM_DEBUG(dbgs() << "\t\tVisiting CFG block: " << curBB->getName()
                       << "\n");

--- a/lib/daedalus.cpp
+++ b/lib/daedalus.cpp
@@ -189,8 +189,6 @@ uint removeInstructions(const std::vector<SliceStruct> &allSlices,
                         const std::set<Function *> &mergeTo,
                         std::set<Function *> &toSimplify) {
   std::set<Instruction *> toRemove;
-  std::map<Instruction *, Function *> newCalls;
-
   uint dontMerge = 0;
 
   for (const SliceStruct &slice : allSlices) {


### PR DESCRIPTION
This pull request refactors and improves the handling of control flow and value cloning in the `ProgramSlice` logic, updates build instructions in the `README.md`, and makes several minor code cleanups and documentation fixes. The most significant changes focus on simplifying and correcting the way conditional values are cloned and how loop-related control flow is handled.

### ProgramSlice logic improvements

* Replaced the `getClonedOrUndef` method with a new `getClonedCond` method in both `ProgramSlice.h` and `ProgramSlice.cpp`, which now more robustly handles cloning of condition values (including `Argument` types) and removes the need for a context parameter. All usages in terminator reconstruction updated accordingly. [[1]](diffhunk://#diff-c1d070e250e89948b4ab7916d5aa4c6f8dd55f33830d35d86383cbb4204490feL131-R131) [[2]](diffhunk://#diff-3720490216df790f3828307dff08e1dcee3074e8b64a9515633b8858c810d686L675-R681) [[3]](diffhunk://#diff-3720490216df790f3828307dff08e1dcee3074e8b64a9515633b8858c810d686L724-R733)
* Improved loop and control flow handling in `getNewTargetByFirstDominator` by skipping loop headers and blocks outside the current loop, and added debug logging for these cases.
* Simplified `getOrCreateTargetBlock` by removing redundant checks for loop containment, relying on improved logic in the dominator-based target selection.