### PR TITLE
Artifact Script Update

### DIFF
--- a/artifact/docker/Dockerfile
+++ b/artifact/docker/Dockerfile
@@ -25,6 +25,7 @@ RUN mkdir -p build
 RUN cmake -G Ninja \
 	-DCMAKE_C_COMPILER=clang \
 	-DCMAKE_CXX_COMPILER=clang++ \
+	-DCMAKE_CXX_FLAGS="-O2" \
 	-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld' \
 	-DCMAKE_BUILD_TYPE="Release" \
 	-DLLVM_TARGETS_TO_BUILD=X86 \
@@ -60,6 +61,7 @@ RUN mkdir -p build
 RUN cmake -G Ninja \
 	-DCMAKE_C_COMPILER=clang \
 	-DCMAKE_CXX_COMPILER=clang++ \
+	-DCMAKE_CXX_FLAGS="-O2" \
 	-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld' \
 	-DCMAKE_BUILD_TYPE="Release" \
 	-DLLVM_TARGETS_TO_BUILD=X86 \

--- a/artifact/docker/Dockerfile
+++ b/artifact/docker/Dockerfile
@@ -23,6 +23,8 @@ RUN git clone --depth 100 -b merge-functions-pass https://github.com/Casperento/
 WORKDIR llvm-project
 RUN mkdir -p build
 RUN cmake -G Ninja \
+	-DCMAKE_C_COMPILER=clang \
+	-DCMAKE_CXX_COMPILER=clang++ \
 	-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld' \
 	-DCMAKE_BUILD_TYPE="Release" \
 	-DLLVM_TARGETS_TO_BUILD=X86 \

--- a/artifact/docker/Dockerfile
+++ b/artifact/docker/Dockerfile
@@ -45,46 +45,28 @@ WORKDIR llvm-test-suite
 RUN mkdir -p build
 RUN mkdir -p /lit-results
 
-RUN cmake -G "Ninja" \
-	-DCMAKE_C_COMPILER=clang \
-	-DCMAKE_CXX_COMPILER=clang++ \
-	-DCMAKE_C_FLAGS="-flto" \
-	-DCMAKE_CXX_FLAGS="-flto" \
-	-DTEST_SUITE_COLLECT_INSTCOUNT=ON \
-	-DTEST_SUITE_SELECTED_PASSES= \
-	-DTEST_SUITE_PASSES_ARGS= \
-	-DTEST_SUITE_COLLECT_COMPILE_TIME=OFF \
-	-DCMAKE_EXE_LINKER_FLAGS="-flto -fuse-ld=lld -Wl,--plugin-opt=-lto-embed-bitcode=post-merge-pre-opt" \
-	"-DTEST_SUITE_SUBDIRS=SingleSource;MultiSource" \
-	-C "cmake/caches/Os.cmake" \
-	-S . -B build
-RUN cmake --build build -- -j 10 || exit 0
-RUN llvm-lit \
-	--timeout 200 \
-	-j 10 \
-    -s \
-    -o /lit-results/baseline.json build || exit 0
+# Clone daedalus-dbg-toolkit to run the experiment
+WORKDIR /src
+RUN git clone https://github.com/Casperento/daedalus-dbg-toolkit.git
+RUN python3 -m pip install -r /src/daedalus-dbg-toolkit/requirements.txt
 
-RUN rm -rf build/*
-
-RUN cmake -G "Ninja" \
-	-DCMAKE_C_COMPILER=clang \
-	-DCMAKE_CXX_COMPILER=clang++ \
-	-DCMAKE_C_FLAGS="-flto" \
-	-DCMAKE_CXX_FLAGS="-flto" \
-	-DTEST_SUITE_COLLECT_INSTCOUNT=ON \
-	-DTEST_SUITE_SELECTED_PASSES=daedalus \
-	"-DTEST_SUITE_PASSES_ARGS=-load-pass-plugin=/src/Daedalus/build/lib/libdaedalus.so" \
-	-DTEST_SUITE_COLLECT_COMPILE_TIME=OFF \
-	-DCMAKE_EXE_LINKER_FLAGS="-flto -fuse-ld=lld -Wl,--plugin-opt=-lto-embed-bitcode=post-merge-pre-opt" \
-	"-DTEST_SUITE_SUBDIRS=SingleSource;MultiSource" \
-	-C "cmake/caches/Os.cmake" \
-	-S . -B build
-RUN cmake --build build -- -k 0 -j 10 || exit 0
-RUN llvm-lit \
-	--timeout 200 \
-	-j 10 \
-    -s \
-    -o /lit-results/daedalus.json build || exit 0
-
-RUN python3 utils/compare.py --full --diff -m instcount -m size..text /lit-results/baseline.json /lit-results/daedalus.json > /lit-results/comparison_results.txt
+# Build llvm with func-merging pass
+RUN git clone --depth 100 -b code-size https://github.com/rcorcs/llvm-project.git code-size
+WORKDIR code-size
+RUN mkdir -p build
+RUN cmake -G Ninja \
+          -DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld' \
+          -DCMAKE_BUILD_TYPE="Release" \
+          -DLLVM_TARGETS_TO_BUILD=X86 \
+          -DLLVM_ENABLE_ASSERTIONS=On \
+          -S llvm -B build
+RUN cmake --build build -- -j 10
+WORKDIR /src/daedalus-dbg-toolkit
+RUN ./run-experiment.sh -w 10 \
+	-t 120 \
+	--llvm-project /src/llvm-project \
+	--code-size-llvm-project /src/code-size \
+	--llvm-test-suite /src/llvm-test-suite \
+	--daedalus /src/Daedalus \
+	--lit-results /lit-results \
+	--errors-dbg /src/daedalus-dbg-toolkit

--- a/artifact/docker/Dockerfile
+++ b/artifact/docker/Dockerfile
@@ -11,8 +11,7 @@ RUN apt install -y sudo \
 	cmake \
 	ninja-build \
 	python3 \
-	python3-venv \
-	clang
+	python3-venv
 
 RUN python3 -m venv /src/venv-py
 ENV PATH="/src/venv-py/bin:$PATH"

--- a/artifact/docker/Dockerfile
+++ b/artifact/docker/Dockerfile
@@ -23,9 +23,6 @@ RUN git clone --depth 100 -b merge-functions-pass https://github.com/Casperento/
 WORKDIR llvm-project
 RUN mkdir -p build
 RUN cmake -G Ninja \
-	-DCMAKE_C_COMPILER=clang \
-	-DCMAKE_CXX_COMPILER=clang++ \
-	-DCMAKE_CXX_FLAGS="-O2" \
 	-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld' \
 	-DCMAKE_BUILD_TYPE="Release" \
 	-DLLVM_TARGETS_TO_BUILD=X86 \
@@ -59,9 +56,6 @@ RUN git clone --depth 100 -b code-size https://github.com/rcorcs/llvm-project.gi
 WORKDIR code-size
 RUN mkdir -p build
 RUN cmake -G Ninja \
-	-DCMAKE_C_COMPILER=clang \
-	-DCMAKE_CXX_COMPILER=clang++ \
-	-DCMAKE_CXX_FLAGS="-O2" \
 	-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld' \
 	-DCMAKE_BUILD_TYPE="Release" \
 	-DLLVM_TARGETS_TO_BUILD=X86 \

--- a/artifact/docker/Dockerfile
+++ b/artifact/docker/Dockerfile
@@ -3,15 +3,16 @@ WORKDIR /src
 
 RUN apt update && apt upgrade -y
 RUN apt install -y sudo \
-                   git \
-                   tcl \
-                   tcl-dev \
-                   vim \
-                   build-essential \
-                   cmake \
-                   ninja-build \
-                   python3 \
-                   python3-venv
+	git \
+	tcl \
+	tcl-dev \
+	vim \
+	build-essential \
+	cmake \
+	ninja-build \
+	python3 \
+	python3-venv \
+	clang
 
 RUN python3 -m venv /src/venv-py
 ENV PATH="/src/venv-py/bin:$PATH"
@@ -22,11 +23,11 @@ RUN git clone --depth 100 -b merge-functions-pass https://github.com/Casperento/
 WORKDIR llvm-project
 RUN mkdir -p build
 RUN cmake -G Ninja \
-          -DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld' \
-          -DCMAKE_BUILD_TYPE="Release" \
-          -DLLVM_TARGETS_TO_BUILD=X86 \
-          -DLLVM_ENABLE_ASSERTIONS=On \
-          -S llvm -B build
+	-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld' \
+	-DCMAKE_BUILD_TYPE="Release" \
+	-DLLVM_TARGETS_TO_BUILD=X86 \
+	-DLLVM_ENABLE_ASSERTIONS=On \
+	-S llvm -B build
 RUN cmake --build build -- -j 10
 ENV PATH="/src/llvm-project/build/bin:$PATH"
 
@@ -55,11 +56,13 @@ RUN git clone --depth 100 -b code-size https://github.com/rcorcs/llvm-project.gi
 WORKDIR code-size
 RUN mkdir -p build
 RUN cmake -G Ninja \
-          -DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld' \
-          -DCMAKE_BUILD_TYPE="Release" \
-          -DLLVM_TARGETS_TO_BUILD=X86 \
-          -DLLVM_ENABLE_ASSERTIONS=On \
-          -S llvm -B build
+	-DCMAKE_C_COMPILER=clang \
+	-DCMAKE_CXX_COMPILER=clang++ \
+	-DLLVM_ENABLE_PROJECTS='clang;compiler-rt;lld' \
+	-DCMAKE_BUILD_TYPE="Release" \
+	-DLLVM_TARGETS_TO_BUILD=X86 \
+	-DLLVM_ENABLE_ASSERTIONS=On \
+	-S llvm -B build
 RUN cmake --build build -- -j 10
 WORKDIR /src/daedalus-dbg-toolkit
 RUN ./run-experiment.sh -w 10 \

--- a/artifact/docker/Dockerfile
+++ b/artifact/docker/Dockerfile
@@ -66,7 +66,7 @@ WORKDIR /src/daedalus-dbg-toolkit
 RUN ./run-experiment.sh -w 10 \
 	-t 120 \
 	--llvm-project /src/llvm-project \
-	--code-size-llvm-project /src/code-size \
+	--code-size /src/code-size \
 	--llvm-test-suite /src/llvm-test-suite \
 	--daedalus /src/Daedalus \
 	--lit-results /lit-results \


### PR DESCRIPTION
This pull request significantly restructures the Docker build process for the LLVM test suite experiment. The previous manual build and test steps have been replaced with a more automated workflow using the [daedalus-dbg-toolkit](https://github.com/Casperento/daedalus-dbg-toolkit) and a custom LLVM build with the func-merging pass. The new approach streamlines experiment setup and execution, integrating external repositories and scripts for improved reproducibility and maintainability.

Experiment automation and workflow update:

* Removed manual CMake build, test, and comparison steps for the LLVM test suite, including explicit configuration for baseline and Daedalus runs.
* Added cloning of the `daedalus-dbg-toolkit` repository and installation of its Python dependencies to automate experiment orchestration.
* Introduced cloning and building of a custom LLVM fork (`code-size` branch) with the func-merging pass, enabling new experimental capabilities.
* Replaced individual build and test commands with execution of the `run-experiment.sh` script from the toolkit, passing all required paths and options for a unified experiment run.