### PR TITLE
Artifact Script Update Fix

### DIFF
--- a/artifact/docker/Dockerfile
+++ b/artifact/docker/Dockerfile
@@ -15,7 +15,6 @@ RUN apt install -y sudo \
 
 RUN python3 -m venv /src/venv-py
 ENV PATH="/src/venv-py/bin:$PATH"
-RUN python3 -m pip install --upgrade pandas scipy psutil
 
 # Clone and Build LLVM 17
 RUN git clone --depth 100 -b merge-functions-pass https://github.com/Casperento/llvm-project.git 
@@ -69,4 +68,5 @@ RUN ./run-experiment.sh -w 10 \
 	--llvm-test-suite /src/llvm-test-suite \
 	--daedalus /src/Daedalus \
 	--lit-results /lit-results \
-	--errors-dbg /src/daedalus-dbg-toolkit
+	--errors-dbg /src/daedalus-dbg-toolkit \
+	--venv /src/venv-py


### PR DESCRIPTION
This pull request makes minor updates to the `artifact/docker/Dockerfile` related to Python virtual environment usage and experiment script configuration.

- Python environment setup:
  * Removed the explicit installation of Python packages (`pandas`, `scipy`, `psutil`) in the virtual environment, possibly delegating package management elsewhere or streamlining the Docker image.

- Experiment script configuration:
  * Added the `--venv /src/venv-py` argument to the `run-experiment.sh` invocation, ensuring the script is aware of the Python virtual environment location.