### PR TITLE
Performance Refactors

### DIFF
--- a/include/ProgramSlice.h
+++ b/include/ProgramSlice.h
@@ -21,13 +21,16 @@
 #include "llvm/Support/Error.h"
 
 // #include "llvm/Transforms/IPO/FunctionMerging.h"
+#include "PHIGateAnalyzer.h"
 
 namespace llvm {
 
 class ProgramSlice {
 public:
   /// Constructs a ProgramSlice object.
-  ProgramSlice(Instruction &I, Function &F, FunctionAnalysisManager &FAM);
+  ProgramSlice(Instruction &I, Function &F, FunctionAnalysisManager &FAM,
+               std::unordered_map<const BasicBlock *,
+                                  SmallVector<const Value *>> &predicates);
 
   /// Checks if current slice can be outlined into a standalone function.
   uint canOutline(AAResults *AA, TargetLibraryInfo &TLI,

--- a/include/ProgramSlice.h
+++ b/include/ProgramSlice.h
@@ -47,7 +47,7 @@ public:
   std::map<Instruction *, Instruction *> getInstructionInSlice();
 
   /// Outlines the given slice into a standalone Function.
-  Function *outline();
+  Function *outline(unsigned int *counter);
 
   /// A function to simplify basic blocks of a function using the same
   /// method as the SimplifyCFGPass

--- a/lib/ProgramSlice.cpp
+++ b/lib/ProgramSlice.cpp
@@ -227,7 +227,8 @@ std::pair<Status, dataDependence> getDataDependencies(
  * LoopInfo.
  */
 ProgramSlice::ProgramSlice(Instruction &Initial, Function &F,
-                           FunctionAnalysisManager &FAM)
+                           FunctionAnalysisManager &FAM,
+                           std::unordered_map<const BasicBlock *, SmallVector<const Value *>> &predicates)
     : _initial(&Initial), _parentFunction(&F) {
 
   assert(Initial.getParent()->getParent() == &F &&
@@ -238,11 +239,6 @@ ProgramSlice::ProgramSlice(Instruction &Initial, Function &F,
   _loopHeader = (_loop) ? _loop->getHeader() : nullptr;
   DominatorTree &DT = FAM.getResult<DominatorTreeAnalysis>(F);
   PostDominatorTree &PDT = FAM.getResult<PostDominatorTreeAnalysis>(F);
-
-  std::unordered_map<const BasicBlock *, SmallVector<const Value *>> predicates;
-
-  PHIGateAnalyzer Analyzer(F, DT);
-  predicates = Analyzer.getGatesForAllPhis();
 
   LLVM_DEBUG({
     dbgs() << "\nPredicates mapping:\n";

--- a/lib/ProgramSlice.cpp
+++ b/lib/ProgramSlice.cpp
@@ -8,7 +8,6 @@
 
 #include <map>
 #include <queue>
-#include <random>
 #include <set>
 #include <stack>
 #include <tuple>
@@ -41,7 +40,6 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Utils/Local.h"
 
-#include "../include/PHIGateAnalyzer.h"
 #include "../include/daedalus.h"
 
 #define DEBUG_TYPE "ProgramSlice"

--- a/lib/daedalus.cpp
+++ b/lib/daedalus.cpp
@@ -490,6 +490,7 @@ PreservedAnalyses DaedalusPass::run(Module &M, ModuleAnalysisManager &MAM) {
   FunctionAnalysisManager &FAM =
       MAM.getResult<FunctionAnalysisManagerModuleProxy>(M).getManager();
 
+  unsigned int outline_counter = 0;
   for (Function *F : FtoMap) {
     uint ki = 0;
     for (auto &BB : *F) {
@@ -567,8 +568,9 @@ PreservedAnalyses DaedalusPass::run(Module &M, ModuleAnalysisManager &MAM) {
         }
       });
 
-      Function *G = ps.outline();
+      Function *G = ps.outline(&outline_counter);
       if (G == nullptr) continue;
+      outline_counter++;
 
       // Get the original instruction to check if it can be removed
       std::map<Instruction *, Instruction *> constOriginalInst =

--- a/lib/daedalus.cpp
+++ b/lib/daedalus.cpp
@@ -5,6 +5,7 @@
  *  @date   2024-07-08
  ***********************************************/
 #include "../include/daedalus.h"
+#include "../include/PHIGateAnalyzer.h"
 #include "../include/ProgramSlice.h"
 #include "../include/debugCommon.h"
 #include "../include/reports.h"
@@ -504,13 +505,19 @@ PreservedAnalyses DaedalusPass::run(Module &M, ModuleAnalysisManager &MAM) {
     // Search for try-catch logic inside the current function
     std::set<const BasicBlock *> tryCatchBlocks = searchForTryCatchLogic(*F);
 
+    // Construct gating functions for all PHI nodes in the function
+    DominatorTree &DT = FAM.getResult<DominatorTreeAnalysis>(*F);
+    PHIGateAnalyzer GSAAnalyzer(*F, DT);
+    std::unordered_map<const BasicBlock *, SmallVector<const Value *>>
+        predicates = GSAAnalyzer.getGatesForAllPhis();
+    LLVM_DEBUG(dbgs() << "daedalus.cpp: Function: " << F->getName() << ",\n");
+
     // Replace all uses of I with the correpondent call to the new outlined
     // function
     for (Instruction *I : S) {
       if (!canBeSliceCriterion(*I)) continue;
 
-      LLVM_DEBUG(dbgs() << "daedalus.cpp: Function: " << F->getName()
-                        << ",\n\tInstruction (Basic Block: "
+      LLVM_DEBUG(dbgs() << "\tInstruction (Basic Block: "
                         << I->getParent()->getName() << "):\n\t\t" << *I
                         << "\n");
 
@@ -523,7 +530,7 @@ PreservedAnalyses DaedalusPass::run(Module &M, ModuleAnalysisManager &MAM) {
         continue;
       }
 
-      ProgramSlice ps = ProgramSlice(*I, *F, FAM);
+      ProgramSlice ps = ProgramSlice(*I, *F, FAM, predicates);
 
       TargetLibraryInfo &TLI = FAM.getResult<TargetLibraryAnalysis>(*F);
       AAResults *AA = &FAM.getResult<AAManager>(*F);

--- a/tests/test10.pattern
+++ b/tests/test10.pattern
@@ -1,5 +1,5 @@
 ; CHECK: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](i64 %0) #4 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](i64 %0) #4 {
 ; CHECK-NEXT: sliceclone_BB_1:
 ; CHECK-NEXT:   %1 = shl nuw nsw i64 %0, 1
 ; CHECK-NEXT:   %2 = trunc i64 %1 to i32
@@ -8,7 +8,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %0, i32 %1) #4 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %0, i32 %1) #4 {
 ; CHECK-NEXT: sliceclone_BB_2:
 ; CHECK-NEXT:   %2 = sext i32 %1 to i64
 ; CHECK-NEXT:   %3 = getelementptr inbounds ptr, ptr %0, i64 %2
@@ -23,7 +23,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %0, i32 %1) #4 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %0, i32 %1) #4 {
 ; CHECK-NEXT: sliceclone_BB_2:
 ; CHECK-NEXT:   %2 = sext i32 %1 to i64
 ; CHECK-NEXT:   %3 = getelementptr inbounds ptr, ptr %0, i64 %2
@@ -41,9 +41,9 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i8 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %0, ptr %1, i32 %2) #4 {
+; CHECK-NEXT: define internal i8 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %0, ptr %1, i32 %2) #4 {
 ; CHECK-NEXT: sliceclone_BB_3:
-; CHECK-NEXT:   %3 = call i32 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %1, i32 %2)
+; CHECK-NEXT:   %3 = call i32 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %1, i32 %2)
 ; CHECK-NEXT:   %4 = sext i32 %3 to i64
 ; CHECK-NEXT:   br label %sliceclone_BB_4
 ; CHECK-EMPTY:
@@ -55,7 +55,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](i32 %0, i32 %1, ptr %2, ptr %3, ptr %4) #4 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](i32 %0, i32 %1, ptr %2, ptr %3, ptr %4) #4 {
 ; CHECK-NEXT: sliceclone_BB_2:
 ; CHECK-NEXT:   %5 = sext i32 %0 to i64
 ; CHECK-NEXT:   %6 = getelementptr inbounds ptr, ptr %3, i64 %5
@@ -70,7 +70,7 @@
 ; CHECK-NEXT:   ret i32 %11
 ; CHECK-EMPTY:
 ; CHECK-NEXT: sliceclone_BB_3:                                  ; preds = %sliceclone_BB_2
-; CHECK-NEXT:   %12 = call i32 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %3, i32 %0)
+; CHECK-NEXT:   %12 = call i32 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %3, i32 %0)
 ; CHECK-NEXT:   %13 = sext i32 %12 to i64
 ; CHECK-NEXT:   %14 = getelementptr inbounds ptr, ptr %4, i64 %13
 ; CHECK-NEXT:   %15 = load ptr, ptr %14, align 8, !tbaa !10
@@ -84,9 +84,9 @@
 ; CHECK-NEXT: sliceclone_BB_4:                                  ; preds = %sliceclone_BB_3
 ; CHECK-NEXT:   %18 = getelementptr inbounds i8, ptr %2, i64 %13
 ; CHECK-NEXT:   %19 = load i8, ptr %18, align 1, !tbaa !7
-; CHECK-NEXT:   %20 = call i32 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %3, i32 %0)
+; CHECK-NEXT:   %20 = call i32 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %3, i32 %0)
 ; CHECK-NEXT:   %21 = icmp eq i32 %20, 0
-; CHECK-NEXT:   %22 = call i8 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %2, ptr %3, i32 %0)
+; CHECK-NEXT:   %22 = call i8 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %2, ptr %3, i32 %0)
 ; CHECK-NEXT:   %23 = select i1 %21, i8 %19, i8 %22
 ; CHECK-NEXT:   %24 = icmp eq i8 %23, 1
 ; CHECK-NEXT:   br i1 %24, label %sliceclone_BB_6, label %sliceclone_BB_5
@@ -96,7 +96,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %0, i32 %1, i32 %2) #4 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %0, i32 %1, i32 %2) #4 {
 ; CHECK-NEXT: sliceclone_BB_9:
 ; CHECK-NEXT:   %3 = add nsw i32 %1, %2
 ; CHECK-NEXT:   br label %sliceclone_BB_10
@@ -115,7 +115,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %0, i32 %1, i32 %2) #4 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %0, i32 %1, i32 %2) #4 {
 ; CHECK-NEXT: sliceclone_BB_9:
 ; CHECK-NEXT:   %3 = add nsw i32 %1, %2
 ; CHECK-NEXT:   br label %sliceclone_BB_10

--- a/tests/test2.pattern
+++ b/tests/test2.pattern
@@ -1,5 +1,5 @@
 ; CHECK: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %0) #3 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %0) #3 {
 ; CHECK-NEXT: sliceclone_BB_1:
 ; CHECK-NEXT:   %1 = getelementptr inbounds ptr, ptr %0, i64 1
 ; CHECK-NEXT:   %2 = load ptr, ptr %1, align 8, !tbaa !11

--- a/tests/test3.pattern
+++ b/tests/test3.pattern
@@ -1,5 +1,5 @@
 ; CHECK: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](i32 %0, ptr %1) #2 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](i32 %0, ptr %1) #2 {
 ; CHECK-NEXT: sliceclone_BB_3:
 ; CHECK-NEXT:   %2 = load ptr, ptr %1, align 8, !tbaa !7
 ; CHECK-NEXT:   %3 = load i8, ptr %2, align 1, !tbaa !11

--- a/tests/test4.pattern
+++ b/tests/test4.pattern
@@ -1,5 +1,5 @@
 ; CHECK: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_tricky_ladder__[[ID:[0-9]+]](i32 %0, i32 %1, i32 %2) #3 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_tricky_ladder_[[ID:[0-9]+]](i32 %0, i32 %1, i32 %2) #3 {
 ; CHECK-NEXT: sliceclone_BB_0:
 ; CHECK-NEXT:   %3 = add nsw i32 %1, %2
 ; CHECK-NEXT:   %4 = icmp slt i32 %2, 41
@@ -36,7 +36,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %0) #3 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %0) #3 {
 ; CHECK-NEXT: sliceclone_BB_2:
 ; CHECK-NEXT:   %1 = getelementptr inbounds ptr, ptr %0, i64 1
 ; CHECK-NEXT:   %2 = load ptr, ptr %1, align 8, !tbaa !7

--- a/tests/test5.pattern
+++ b/tests/test5.pattern
@@ -1,5 +1,5 @@
 ; CHECK: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](i64 %0, i64 %1) #9 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](i64 %0, i64 %1) #9 {
 ; CHECK-NEXT: sliceclone_BB_2:
 ; CHECK-NEXT:   %2 = mul nuw nsw i64 %0, %1
 ; CHECK-NEXT:   %3 = trunc i64 %2 to i32
@@ -8,7 +8,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](i64 %0, i64 %1) #9 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](i64 %0, i64 %1) #9 {
 ; CHECK-NEXT: sliceclone_BB_2:
 ; CHECK-NEXT:   %2 = sub nsw i64 %0, %1
 ; CHECK-NEXT:   %3 = trunc i64 %2 to i32
@@ -17,7 +17,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](i64 %0, i64 %1) #9 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](i64 %0, i64 %1) #9 {
 ; CHECK-NEXT: sliceclone_BB_6:
 ; CHECK-NEXT:   %2 = mul nuw nsw i64 %0, %1
 ; CHECK-NEXT:   %3 = trunc i64 %2 to i32
@@ -26,7 +26,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](i64 %0, i64 %1) #9 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](i64 %0, i64 %1) #9 {
 ; CHECK-NEXT: sliceclone_BB_6:
 ; CHECK-NEXT:   %2 = sub nsw i64 %0, %1
 ; CHECK-NEXT:   %3 = trunc i64 %2 to i32
@@ -35,7 +35,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_kernel_dynprog__[[ID:[0-9]+]](ptr %0, i32 %1, i64 %2, i64 %3) #9 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_kernel_dynprog_[[ID:[0-9]+]](ptr %0, i32 %1, i64 %2, i64 %3) #9 {
 ; CHECK-NEXT: sliceclone_BB_6:
 ; CHECK-NEXT:   %4 = getelementptr inbounds [50 x i32], ptr %0, i64 %2, i64 %3
 ; CHECK-NEXT:   %5 = load i32, ptr %4, align 4, !tbaa !11
@@ -44,9 +44,9 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_kernel_dynprog__[[ID:[0-9]+]](ptr %0, i32 %1, i64 %2, i64 %3, i64 %4) #9 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_kernel_dynprog_[[ID:[0-9]+]](ptr %0, i32 %1, i64 %2, i64 %3, i64 %4) #9 {
 ; CHECK-NEXT: sliceclone_BB_6:
-; CHECK-NEXT:   %5 = call i32 @_daedalus_slice_kernel_dynprog__[[ID:[0-9]+]](ptr %0, i32 %1, i64 %2, i64 %3)
+; CHECK-NEXT:   %5 = call i32 @_daedalus_slice_kernel_dynprog_[[ID:[0-9]+]](ptr %0, i32 %1, i64 %2, i64 %3)
 ; CHECK-NEXT:   %6 = getelementptr inbounds [50 x i32], ptr %0, i64 %3, i64 %4
 ; CHECK-NEXT:   %7 = load i32, ptr %6, align 4, !tbaa !11
 ; CHECK-NEXT:   %8 = add nsw i32 %5, %7

--- a/tests/test6.pattern
+++ b/tests/test6.pattern
@@ -1,5 +1,5 @@
 ; CHECK: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i64 @_daedalus_slice_main__[[ID:[0-9]+]](i32 %0, ptr %1) #6 {
+; CHECK-NEXT: define internal i64 @_daedalus_slice_main_[[ID:[0-9]+]](i32 %0, ptr %1) #6 {
 ; CHECK-NEXT: sliceclone_BB_0:
 ; CHECK-NEXT:   %2 = icmp sgt i32 %0, 1
 ; CHECK-NEXT:   br i1 %2, label %sliceclone_BB_1, label %sliceclone_BB_12
@@ -68,7 +68,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i64 @_daedalus_slice_main__[[ID:[0-9]+]](i32 %0, ptr %1) #6 {
+; CHECK-NEXT: define internal i64 @_daedalus_slice_main_[[ID:[0-9]+]](i32 %0, ptr %1) #6 {
 ; CHECK-NEXT: sliceclone_BB_0:
 ; CHECK-NEXT:   %2 = icmp sgt i32 %0, 1
 ; CHECK-NEXT:   br i1 %2, label %sliceclone_BB_1, label %sliceclone_BB_12
@@ -140,7 +140,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](i32 %0, ptr %1) #6 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](i32 %0, ptr %1) #6 {
 ; CHECK-NEXT: sliceclone_BB_26:
 ; CHECK-NEXT:   %2 = getelementptr inbounds %struct.element, ptr %1, i64 0, i32 1
 ; CHECK-NEXT:   %3 = load i32, ptr %2, align 8, !tbaa !18
@@ -149,7 +149,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %0) #6 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %0) #6 {
 ; CHECK-NEXT: sliceclone_BB_26:
 ; CHECK-NEXT:   %1 = getelementptr inbounds %struct.element, ptr %0, i64 0, i32 1
 ; CHECK-NEXT:   %2 = load i32, ptr %1, align 8, !tbaa !18

--- a/tests/test7.pattern
+++ b/tests/test7.pattern
@@ -1,5 +1,5 @@
 ; CHECK: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i32 @_daedalus_slice_main__[[ID:[0-9]+]](ptr %0) #3 {
+; CHECK-NEXT: define internal i32 @_daedalus_slice_main_[[ID:[0-9]+]](ptr %0) #3 {
 ; CHECK-NEXT: sliceclone_BB_1:
 ; CHECK-NEXT:   %1 = getelementptr inbounds ptr, ptr %0, i64 1
 ; CHECK-NEXT:   %2 = load ptr, ptr %1, align 8, !tbaa !7

--- a/tests/test8.pattern
+++ b/tests/test8.pattern
@@ -1,5 +1,5 @@
 ; CHECK: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal float @_daedalus_slice_check__[[ID:[0-9]+]](float %0, i64 %1, i64 %2) #8 {
+; CHECK-NEXT: define internal float @_daedalus_slice_check_[[ID:[0-9]+]](float %0, i64 %1, i64 %2) #8 {
 ; CHECK-NEXT: sliceclone_BB_4:
 ; CHECK-NEXT:   %3 = getelementptr inbounds [256 x float], ptr getelementptr inbounds (%struct.GlobalData, ptr @global_data, i64 0, i32 15, i64 0, i64 0), i64 %1, i64 %2
 ; CHECK-NEXT:   %4 = load float, ptr %3, align 4, !tbaa !7
@@ -8,7 +8,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal float @_daedalus_slice_check__[[ID:[0-9]+]](float %0, i64 %1, i64 %2) #8 {
+; CHECK-NEXT: define internal float @_daedalus_slice_check_[[ID:[0-9]+]](float %0, i64 %1, i64 %2) #8 {
 ; CHECK-NEXT: sliceclone_BB_4:
 ; CHECK-NEXT:   %3 = getelementptr inbounds [256 x float], ptr getelementptr inbounds (%struct.GlobalData, ptr @global_data, i64 0, i32 18, i64 0, i64 0), i64 %1, i64 %2
 ; CHECK-NEXT:   %4 = load float, ptr %3, align 4, !tbaa !7
@@ -17,7 +17,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal float @_daedalus_slice_check__[[ID:[0-9]+]](float %0, i64 %1, i64 %2) #8 {
+; CHECK-NEXT: define internal float @_daedalus_slice_check_[[ID:[0-9]+]](float %0, i64 %1, i64 %2) #8 {
 ; CHECK-NEXT: sliceclone_BB_4:
 ; CHECK-NEXT:   %3 = getelementptr inbounds [256 x float], ptr getelementptr inbounds (%struct.GlobalData, ptr @global_data, i64 0, i32 21, i64 0, i64 0), i64 %1, i64 %2
 ; CHECK-NEXT:   %4 = load float, ptr %3, align 4, !tbaa !7
@@ -26,7 +26,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal float @_daedalus_slice_check__[[ID:[0-9]+]]() #8 {
+; CHECK-NEXT: define internal float @_daedalus_slice_check_[[ID:[0-9]+]]() #8 {
 ; CHECK-NEXT: sliceclone_BB_0:
 ; CHECK-NEXT:   br label %sliceclone_BB_1
 ; CHECK-EMPTY:
@@ -53,8 +53,8 @@
 ; CHECK-NEXT:   %10 = phi i64 [ 0, %sliceclone_BB_2 ], [ %15, %sliceclone_BB_4 ]
 ; CHECK-NEXT:   %11 = phi float [ %4, %sliceclone_BB_2 ], [ %14, %sliceclone_BB_4 ]
 ; CHECK-NEXT:   %12 = phi float [ %5, %sliceclone_BB_2 ], [ %13, %sliceclone_BB_4 ]
-; CHECK-NEXT:   %13 = call float @_daedalus_slice_check__[[ID:[0-9]+]](float %12, i64 %3, i64 %10)
-; CHECK-NEXT:   %14 = call float @_daedalus_slice_check__[[ID:[0-9]+]](float %11, i64 %3, i64 %10)
+; CHECK-NEXT:   %13 = call float @_daedalus_slice_check_[[ID:[0-9]+]](float %12, i64 %3, i64 %10)
+; CHECK-NEXT:   %14 = call float @_daedalus_slice_check_[[ID:[0-9]+]](float %11, i64 %3, i64 %10)
 ; CHECK-NEXT:   %15 = add nuw nsw i64 %10, 1
 ; CHECK-NEXT:   %16 = icmp eq i64 %15, 256
 ; CHECK-NEXT:   br i1 %16, label %sliceclone_BB_3, label %sliceclone_BB_4
@@ -100,7 +100,7 @@
 ; CHECK-NEXT: }
 ; CHECK-EMPTY:
 ; CHECK-NEXT: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal float @_daedalus_slice_check__[[ID:[0-9]+]]() #8 {
+; CHECK-NEXT: define internal float @_daedalus_slice_check_[[ID:[0-9]+]]() #8 {
 ; CHECK-NEXT: sliceclone_BB_0:
 ; CHECK-NEXT:   br label %sliceclone_BB_1
 ; CHECK-EMPTY:
@@ -127,8 +127,8 @@
 ; CHECK-NEXT:   %10 = phi i64 [ 0, %sliceclone_BB_2 ], [ %15, %sliceclone_BB_4 ]
 ; CHECK-NEXT:   %11 = phi float [ %4, %sliceclone_BB_2 ], [ %14, %sliceclone_BB_4 ]
 ; CHECK-NEXT:   %12 = phi float [ %5, %sliceclone_BB_2 ], [ %13, %sliceclone_BB_4 ]
-; CHECK-NEXT:   %13 = call float @_daedalus_slice_check__[[ID:[0-9]+]](float %12, i64 %3, i64 %10)
-; CHECK-NEXT:   %14 = call float @_daedalus_slice_check__[[ID:[0-9]+]](float %11, i64 %3, i64 %10)
+; CHECK-NEXT:   %13 = call float @_daedalus_slice_check_[[ID:[0-9]+]](float %12, i64 %3, i64 %10)
+; CHECK-NEXT:   %14 = call float @_daedalus_slice_check_[[ID:[0-9]+]](float %11, i64 %3, i64 %10)
 ; CHECK-NEXT:   %15 = add nuw nsw i64 %10, 1
 ; CHECK-NEXT:   %16 = icmp eq i64 %15, 256
 ; CHECK-NEXT:   br i1 %16, label %sliceclone_BB_3, label %sliceclone_BB_4

--- a/tests/test9.pattern
+++ b/tests/test9.pattern
@@ -1,5 +1,5 @@
 ; CHECK: ; Function Attrs: noinline nounwind optsize willreturn
-; CHECK-NEXT: define internal i64 @_daedalus_slice_simplified__[[ID:[0-9]+]](i64 %0, ptr %1, i64 %2) #5 {
+; CHECK-NEXT: define internal i64 @_daedalus_slice_simplified_[[ID:[0-9]+]](i64 %0, ptr %1, i64 %2) #5 {
 ; CHECK-NEXT: sliceclone_BB_0:
 ; CHECK-NEXT:   %3 = add nsw i64 %2, -1
 ; CHECK-NEXT:   %4 = sdiv i64 %3, 2


### PR DESCRIPTION
Closes #34

This pull request refactors the `PathExpr` representation to improve performance, clarity, and maintainability. The core change replaces the `std::variant` and `std::shared_ptr`-based implementation with a simpler, custom pointer-based `PathExpr` class.

This new approach simplifies the data structure, reduces dynamic memory management overhead, and makes the path expression logic more explicit.

### Major Changes

* **Refactored `PathExpr` to a Custom Class**: Replaced the `std::variant`-based `PathExpr` with a single, pointer-based class. This new class uses an `enum` for type dispatching instead of `std::visit`, eliminating dynamic polymorphism and simplifying memory management. All related creation and manipulation methods (`createEdgeExpr`, `mergePaths`, etc.) have been updated.
    * *(Files: `include/PHIGateAnalyzer.h`, `lib/PHIGateAnalyzer.cpp`)*

* **Improved Performance and Determinism**:
    * **Optimization**: Predicates are now computed only once per analyzed function, avoiding redundant work.
    * **Determinism**: Replaced the non-deterministic (random number-based) naming for outlined functions with a stable, sequential counter.

### API Updates and Cleanup

* **API Changes**: Updated the `ProgramSlice` constructor and `outline` method signatures to reflect the new `PathExpr` interface.
    * *(File: `include/ProgramSlice.h`)*
* **Code Simplification**: Removed now-unnecessary helper structs and `std::visit` patterns. All traversal, collection, and printing logic has been consolidated into the new `PathExpr` class.
    * *(Files: `include/PHIGateAnalyzer.h`, `lib/PHIGateAnalyzer.cpp`)*